### PR TITLE
Check return value of fscanf()

### DIFF
--- a/services/rc_battery_monitor/src/rc_battery_monitor.c
+++ b/services/rc_battery_monitor/src/rc_battery_monitor.c
@@ -297,7 +297,7 @@ void shutdown_signal_handler(int signo)
 int kill_existing_instance()
 {
 	FILE* fd;
-	int old_pid, i;
+	int old_pid, r, i;
 
 	// attempt to open PID file
 	fd = fopen(BATTPIDFILE, "r");
@@ -308,12 +308,12 @@ int kill_existing_instance()
 	}
 
 	// otherwise try to read the current process ID
-	fscanf(fd,"%d", &old_pid);
+	r = fscanf(fd,"%d", &old_pid);
 	fclose(fd);
 
 	// if the file didn't contain a PID number, remove it and
 	// return -1 indicating weird behavior
-	if(old_pid == 0){
+	if(r != 1){
 		remove(BATTPIDFILE);
 		return 1;
 	}


### PR DESCRIPTION
The variable old_pid is read, but may not have been written by fscanf(). It should be guarded by a check that the call to fscanf returns at least 1.