### PR TITLE
Expose library include headers

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -42,7 +42,7 @@ if(DEFINED __RC_V0_3)
 		serial_ports/rc_uart.c
 	)
 
-	target_include_directories(robotics_cape PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+	target_include_directories(robotics_cape PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 else()
 


### PR DESCRIPTION
Small change to the `library/CMakeLists.txt` to allow for people who are integrating the library into their projects to use the library headers more easily. 