### PR TITLE
readme: Fix broken link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Robot Control Library
 This package contains the C library and example/testing programs for the Robot Control project. This project began as a hardware interface for the Robotics Cape and later the BeagleBone Blue and was originally called Robotics_Cape_Installer. It grew to include an extensive math library for discrete time feedback control, as well as a plethora of POSIX-compliant functions for timing, threads, program flow, and lots more, all aimed at developing robot control software on embedded computers.
 
 
-Full API documentation, instruction manual, and examples at <http://docs.beagle.cc/project/librobotcontrol>.
+Full API documentation, instruction manual, and examples at <https://docs.beagleboard.org/projects/librobotcontrol/>.
 
 We encourage questions and discussion in the [Discord #librobotcontrol channel](https://discord.gg/PZUsdBqe).
 


### PR DESCRIPTION
The link to API is broken and leads to "Page Not Found (404)". Replace that link with the correct one.